### PR TITLE
fix: Sort API list alphabetically

### DIFF
--- a/lib/Service/AppsService.php
+++ b/lib/Service/AppsService.php
@@ -18,7 +18,7 @@ class AppsService {
 	 * @return string[]
 	 */
 	public function findSupported(): array {
-		$apis = ['core'];
+		$apis = [];
 
 		foreach ($this->appManager->getInstalledApps() as $app) {
 			try {
@@ -34,6 +34,11 @@ class AppsService {
 			} catch (AppPathNotFoundException) {
 			}
 		}
+
+		sort($apis);
+
+		array_unshift($apis, 'core');
+
 		return $apis;
 	}
 


### PR DESCRIPTION
Before | After
---|---
List is sorted by app ID and inside the app ID by file modification time (aka random) | Sorted fully alphabetically with `core` cheated to the top.
![grafik](https://github.com/nextcloud/ocs_api_viewer/assets/213943/8197fcf7-0003-4d33-b86c-72e662a36b11) | ![grafik](https://github.com/nextcloud/ocs_api_viewer/assets/213943/0cddd3c8-2dd3-4641-8d74-0a73badb6bc3)
