### PR TITLE
Fix OpenAPI paths when NC is not served at the webserver's root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ composer:
 
 .PHONY: npm
 npm:
+	npm ci
 	npm run build
 
 .PHONY: clean

--- a/lib/Service/AppsService.php
+++ b/lib/Service/AppsService.php
@@ -8,10 +8,14 @@ namespace OCA\OCSAPIViewer\Service;
 use OC;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
+use OCP\IURLGenerator;
 
 class AppsService {
 
-	public function __construct(private IAppManager $appManager) {
+	public function __construct(
+		private IAppManager $appManager,
+		private IURLGenerator $url,
+	) {
 	}
 
 	/**
@@ -84,6 +88,15 @@ class AppsService {
 				}
 				$operation = &$data['paths'][$path][$method];
 				unset($operation['security']);
+			}
+		}
+		// fix paths when NC is accessed at a sub path
+		$webRoot = $this->url->getWebroot();
+		if ($webRoot !== '' && $webRoot !== '/') {
+			foreach (array_keys($data['paths']) as $path) {
+				$prefixedPath = $webRoot . $path;
+				$data['paths'][$prefixedPath] = $data['paths'][$path];
+				unset($data['paths'][$path]);
 			}
 		}
 

--- a/lib/Service/AppsService.php
+++ b/lib/Service/AppsService.php
@@ -45,7 +45,7 @@ class AppsService {
 	private function getSpecPath(string $app): ?string {
 		$scopeSuffix = '';
 		if ($app === 'core') {
-			$baseDir = OC::$SERVERROOT . DIRECTORY_SEPARATOR . "core";
+			$baseDir = OC::$SERVERROOT . DIRECTORY_SEPARATOR . 'core';
 		} else {
 			try {
 				if (str_contains($app, '-')) {
@@ -65,25 +65,25 @@ class AppsService {
 		$data = json_decode(file_get_contents($this->getSpecPath($app)), true);
 
 		// Only give basic authentication as an option
-		$data["components"]["securitySchemes"] = [
-			"basic_auth" => [
-				"type" => "http",
-				"scheme" => "basic",
+		$data['components']['securitySchemes'] = [
+			'basic_auth' => [
+				'type' => 'http',
+				'scheme' => 'basic',
 			],
 		];
-		$data["security"] = [
+		$data['security'] = [
 			[
-				"basic_auth" => [],
+				'basic_auth' => [],
 			],
 		];
 		// Delete individual security requirements
-		foreach (array_keys($data["paths"]) as $path) {
-			foreach (array_keys($data["paths"][$path]) as $method) {
-				if (!in_array($method, ["delete", "get", "post", "put", "patch", "options"])) {
+		foreach (array_keys($data['paths']) as $path) {
+			foreach (array_keys($data['paths'][$path]) as $method) {
+				if (!in_array($method, ['delete', 'get', 'post', 'put', 'patch', 'options'])) {
 					continue;
 				}
-				$operation = &$data["paths"][$path][$method];
-				unset($operation["security"]);
+				$operation = &$data['paths'][$path][$method];
+				unset($operation['security']);
 			}
 		}
 


### PR DESCRIPTION
Off topic:

* use simple quotes
* add missing `npm ci` in makefile

In topic:

If NC is accessible at `https://domain.org/sub/path`, Stoplights/elements will make requests to `https://domain.org/ocs/v2.php/apps/...` instead of `https://domain.org/sub/path/ocs/v2.php/apps/...`.

There is apparently no way to give a path prefix to elements.
So one solution is to change the paths on the fly in `openapi.json`'s content when serving it.
Downside: The displayed path in the UI is not relative to NC's root anymore but to the webserver's root.

![image](https://github.com/nextcloud/ocs_api_viewer/assets/11291457/f54b967b-cb93-46ee-b0ae-217e7c0d76f8)
