### PR TITLE
fix(build): Add missing eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+	extends: [
+		'@nextcloud',
+	],
+	rules: {
+		'jsdoc/require-jsdoc': 'off',
+		'vue/first-attribute-linebreak': 'off',
+	},
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Add missing eslint config
 
 # 1.0.5
 - Fix nonce


### PR DESCRIPTION
Release build failed because of missing eslint config https://github.com/nextcloud-releases/ocs_api_viewer/actions/runs/8246943298/job/22554067365