### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2313,21 +2313,30 @@
 			}
 		},
 		"node_modules/@nextcloud/l10n": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.1.0.tgz",
-			"integrity": "sha512-unciqr8QSJ29vFBw9S1bquyoj1PTWHszNL8tcUNuxUAYpq0hX+8o7rpB5gimELA4sj4m9+VCJwgLtBZd1Yj0lg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.2.0.tgz",
+			"integrity": "sha512-5TbIc415C0r8YUA0i4bOXKL0iInY8ka+t8PGHihqevzqf/LAkFatd+p6mCLJT3tQPxgkcIRCIuyOkiUM0Lyw5Q==",
+			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/router": "^3.0.1",
-				"@nextcloud/typings": "^1.8.0",
-				"@types/dompurify": "^3.0.5",
+				"@nextcloud/typings": "^1.9.1",
+				"@types/dompurify": "^3.2.0",
 				"@types/escape-html": "^1.0.4",
-				"dompurify": "^3.1.2",
-				"escape-html": "^1.0.3",
-				"node-gettext": "^3.0.0"
+				"dompurify": "^3.2.4",
+				"escape-html": "^1.0.3"
 			},
 			"engines": {
 				"node": "^20.0.0",
 				"npm": "^10.0.0"
+			}
+		},
+		"node_modules/@nextcloud/l10n/node_modules/dompurify": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+			"integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/@nextcloud/logger": {
@@ -2414,9 +2423,10 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "8.22.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.22.0.tgz",
-			"integrity": "sha512-6smeLUVLl8lqh+ia9j+m3nk9fnjra/YNgNO8RI1He8LRuojB9ZQtIy3kGcqIN1BOi6fx9qLiBEkobazWzMmiSw==",
+			"version": "8.23.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.23.1.tgz",
+			"integrity": "sha512-VKvXvUilaeuuZC0jYEokZmylxLUxxR+LDdpZchhZZgc1de0EcGMRMs/2OGriL8Kn6SjrtLRJb4rPtrUekpMi0Q==",
+			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",
 				"@linusborg/vue-simple-portal": "^0.1.5",
@@ -2426,7 +2436,7 @@
 				"@nextcloud/capabilities": "^1.2.0",
 				"@nextcloud/event-bus": "^3.3.1",
 				"@nextcloud/initial-state": "^2.2.0",
-				"@nextcloud/l10n": "^3.1.0",
+				"@nextcloud/l10n": "^3.2.0",
 				"@nextcloud/logger": "^3.0.2",
 				"@nextcloud/router": "^3.0.1",
 				"@nextcloud/sharing": "^0.2.3",
@@ -2436,7 +2446,7 @@
 				"@vueuse/core": "^11.0.0",
 				"clone": "^2.1.2",
 				"debounce": "^2.2.0",
-				"dompurify": "^3.0.5",
+				"dompurify": "^3.2.4",
 				"emoji-mart-vue-fast": "^15.0.1",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^1.0.0-beta.19",
@@ -2444,10 +2454,10 @@
 				"linkify-string": "^4.0.0",
 				"md5": "^2.3.0",
 				"rehype-external-links": "^3.0.0",
-				"rehype-highlight": "^7.0.1",
+				"rehype-highlight": "^7.0.2",
 				"rehype-react": "^7.1.2",
 				"remark-breaks": "^4.0.0",
-				"remark-gfm": "^4.0.0",
+				"remark-gfm": "^4.0.1",
 				"remark-parse": "^11.0.0",
 				"remark-rehype": "^11.0.0",
 				"splitpanes": "^2.4.1",
@@ -2477,6 +2487,15 @@
 			},
 			"peerDependencies": {
 				"vue": "2.x"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/dompurify": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+			"integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/@nextcloud/webpack-vue-config": {
@@ -3539,16 +3558,21 @@
 		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+			"integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/ms": "*"
 			}
 		},
 		"node_modules/@types/dompurify": {
-			"version": "3.0.5",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
+			"integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
+			"deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
 			"license": "MIT",
 			"dependencies": {
-				"@types/trusted-types": "*"
+				"dompurify": "*"
 			}
 		},
 		"node_modules/@types/escape-html": {
@@ -3684,6 +3708,15 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
 		"node_modules/@types/mime": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -3692,7 +3725,9 @@
 			"peer": true
 		},
 		"node_modules/@types/ms": {
-			"version": "0.7.34",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
@@ -3815,7 +3850,10 @@
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/@types/unist": {
 			"version": "2.0.10",
@@ -5588,6 +5626,8 @@
 		},
 		"node_modules/ccount": {
 			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -5603,6 +5643,8 @@
 		},
 		"node_modules/character-entities": {
 			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -6333,6 +6375,8 @@
 		},
 		"node_modules/decode-named-character-reference": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+			"integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
 			"license": "MIT",
 			"dependencies": {
 				"character-entities": "^2.0.0"
@@ -8717,6 +8761,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
 			"integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
 				"@types/unist": "^3.0.0",
@@ -8732,6 +8777,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
 			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
 			}
@@ -8739,7 +8785,8 @@
 		"node_modules/hast-util-to-text/node_modules/@types/unist": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"license": "MIT"
 		},
 		"node_modules/hast-util-whitespace": {
 			"version": "2.0.1",
@@ -9926,10 +9973,6 @@
 			"version": "4.0.8",
 			"license": "MIT"
 		},
-		"node_modules/lodash.get": {
-			"version": "4.4.2",
-			"license": "MIT"
-		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"dev": true,
@@ -9949,6 +9992,8 @@
 		},
 		"node_modules/longest-streak": {
 			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -10016,7 +10061,9 @@
 			"peer": true
 		},
 		"node_modules/markdown-table": {
-			"version": "3.0.3",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+			"integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -10082,13 +10129,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-find-and-replace/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
 			"version": "5.0.0",
 			"license": "MIT",
@@ -10100,7 +10140,9 @@
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
-			"version": "2.0.0",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+			"integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -10121,30 +10163,16 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-from-markdown/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/mdast-util-from-markdown/node_modules/@types/unist": {
-			"version": "3.0.2",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
 			"license": "MIT"
 		},
-		"node_modules/mdast-util-from-markdown/node_modules/mdast-util-to-string": {
-			"version": "4.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/mdast-util-gfm": {
-			"version": "3.0.0",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+			"integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
 			"license": "MIT",
 			"dependencies": {
 				"mdast-util-from-markdown": "^2.0.0",
@@ -10161,7 +10189,9 @@
 			}
 		},
 		"node_modules/mdast-util-gfm-autolink-literal": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+			"integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -10175,15 +10205,10 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-gfm-autolink-literal/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/mdast-util-gfm-footnote": {
-			"version": "2.0.0",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -10197,15 +10222,10 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-gfm-footnote/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/mdast-util-gfm-strikethrough": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+			"integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -10217,15 +10237,10 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-gfm-strikethrough/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/mdast-util-gfm-table": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+			"integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -10239,15 +10254,10 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-gfm-table/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/mdast-util-gfm-task-list-item": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+			"integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -10258,13 +10268,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-gfm-task-list-item/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
 			}
 		},
 		"node_modules/mdast-util-newline-to-break": {
@@ -10279,15 +10282,10 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-newline-to-break/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/mdast-util-phrasing": {
 			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -10298,15 +10296,10 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-phrasing/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/mdast-util-to-markdown": {
-			"version": "2.1.0",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -10314,6 +10307,7 @@
 				"longest-streak": "^3.0.0",
 				"mdast-util-phrasing": "^4.0.0",
 				"mdast-util-to-string": "^4.0.0",
+				"micromark-util-classify-character": "^2.0.0",
 				"micromark-util-decode-string": "^2.0.0",
 				"unist-util-visit": "^5.0.0",
 				"zwitch": "^2.0.0"
@@ -10323,19 +10317,16 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/mdast-util-to-markdown/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/mdast-util-to-markdown/node_modules/@types/unist": {
-			"version": "3.0.2",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
 			"license": "MIT"
 		},
-		"node_modules/mdast-util-to-markdown/node_modules/mdast-util-to-string": {
+		"node_modules/mdast-util-to-string": {
 			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0"
@@ -10444,7 +10435,9 @@
 			}
 		},
 		"node_modules/micromark": {
-			"version": "4.0.0",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.1.tgz",
+			"integrity": "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10477,7 +10470,9 @@
 			}
 		},
 		"node_modules/micromark-core-commonmark": {
-			"version": "2.0.0",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz",
+			"integrity": "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10510,6 +10505,8 @@
 		},
 		"node_modules/micromark-extension-gfm": {
 			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+			"integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
 			"license": "MIT",
 			"dependencies": {
 				"micromark-extension-gfm-autolink-literal": "^2.0.0",
@@ -10527,7 +10524,9 @@
 			}
 		},
 		"node_modules/micromark-extension-gfm-autolink-literal": {
-			"version": "2.0.0",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+			"integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
 			"license": "MIT",
 			"dependencies": {
 				"micromark-util-character": "^2.0.0",
@@ -10541,7 +10540,9 @@
 			}
 		},
 		"node_modules/micromark-extension-gfm-footnote": {
-			"version": "2.0.0",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
 			"license": "MIT",
 			"dependencies": {
 				"devlop": "^1.0.0",
@@ -10559,7 +10560,9 @@
 			}
 		},
 		"node_modules/micromark-extension-gfm-strikethrough": {
-			"version": "2.0.0",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+			"integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
 			"license": "MIT",
 			"dependencies": {
 				"devlop": "^1.0.0",
@@ -10575,7 +10578,9 @@
 			}
 		},
 		"node_modules/micromark-extension-gfm-table": {
-			"version": "2.0.0",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+			"integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
 			"license": "MIT",
 			"dependencies": {
 				"devlop": "^1.0.0",
@@ -10591,6 +10596,8 @@
 		},
 		"node_modules/micromark-extension-gfm-tagfilter": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+			"integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
 			"license": "MIT",
 			"dependencies": {
 				"micromark-util-types": "^2.0.0"
@@ -10601,7 +10608,9 @@
 			}
 		},
 		"node_modules/micromark-extension-gfm-task-list-item": {
-			"version": "2.0.1",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+			"integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
 			"license": "MIT",
 			"dependencies": {
 				"devlop": "^1.0.0",
@@ -10616,7 +10625,9 @@
 			}
 		},
 		"node_modules/micromark-factory-destination": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10635,7 +10646,9 @@
 			}
 		},
 		"node_modules/micromark-factory-label": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10655,7 +10668,9 @@
 			}
 		},
 		"node_modules/micromark-factory-space": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10673,7 +10688,9 @@
 			}
 		},
 		"node_modules/micromark-factory-title": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10693,7 +10710,9 @@
 			}
 		},
 		"node_modules/micromark-factory-whitespace": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10731,7 +10750,9 @@
 			}
 		},
 		"node_modules/micromark-util-chunked": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10748,7 +10769,9 @@
 			}
 		},
 		"node_modules/micromark-util-classify-character": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10767,7 +10790,9 @@
 			}
 		},
 		"node_modules/micromark-util-combine-extensions": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10785,7 +10810,9 @@
 			}
 		},
 		"node_modules/micromark-util-decode-numeric-character-reference": {
-			"version": "2.0.1",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10802,7 +10829,9 @@
 			}
 		},
 		"node_modules/micromark-util-decode-string": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10836,7 +10865,9 @@
 			"license": "MIT"
 		},
 		"node_modules/micromark-util-html-tag-name": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10850,7 +10881,9 @@
 			"license": "MIT"
 		},
 		"node_modules/micromark-util-normalize-identifier": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10867,7 +10900,9 @@
 			}
 		},
 		"node_modules/micromark-util-resolve-all": {
-			"version": "2.0.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -10903,7 +10938,9 @@
 			}
 		},
 		"node_modules/micromark-util-subtokenize": {
-			"version": "2.0.0",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.4.tgz",
+			"integrity": "sha512-N6hXjrin2GTJDe3MVjf5FuXpm12PGm80BrUAeub9XFXca8JZbP+oIwY4LJSVwFUCL1IPm/WwSVUN7goFHmSGGQ==",
 			"funding": [
 				{
 					"type": "GitHub Sponsors",
@@ -11208,12 +11245,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 6.13.0"
-			}
-		},
-		"node_modules/node-gettext": {
-			"version": "3.0.0",
-			"dependencies": {
-				"lodash.get": "^4.4.2"
 			}
 		},
 		"node_modules/node-gyp-build": {
@@ -12798,9 +12829,10 @@
 			}
 		},
 		"node_modules/rehype-highlight": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.1.tgz",
-			"integrity": "sha512-dB/vVGFsbm7xPglqnYbg0ABg6rAuIWKycTvuXaOO27SgLoOFNoTlniTBtAxp3n5ZyMioW1a3KwiNqgjkb6Skjg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+			"integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
 				"hast-util-to-text": "^4.0.0",
@@ -12817,6 +12849,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
 			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
 			}
@@ -12825,6 +12858,7 @@
 			"version": "11.11.1",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
 			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -12833,6 +12867,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
 			"integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
 				"devlop": "^1.0.0",
@@ -12959,15 +12994,10 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/remark-breaks/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/remark-gfm": {
-			"version": "4.0.0",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+			"integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -12982,28 +13012,10 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/remark-gfm/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
-		"node_modules/remark-gfm/node_modules/remark-stringify": {
-			"version": "11.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"mdast-util-to-markdown": "^2.0.0",
-				"unified": "^11.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/remark-parse": {
 			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mdast": "^4.0.0",
@@ -13014,13 +13026,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-parse/node_modules/@types/mdast": {
-			"version": "4.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
 			}
 		},
 		"node_modules/remark-rehype": {
@@ -13040,13 +13045,6 @@
 		},
 		"node_modules/remark-rehype/node_modules/@types/hast": {
 			"version": "3.0.4",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
-		"node_modules/remark-rehype/node_modules/@types/mdast": {
-			"version": "4.0.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
@@ -13080,6 +13078,21 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -15412,6 +15425,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
 			"integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
 				"unist-util-is": "^6.0.0"
@@ -15424,7 +15438,8 @@
 		"node_modules/unist-util-find-after/node_modules/@types/unist": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"license": "MIT"
 		},
 		"node_modules/unist-util-is": {
 			"version": "6.0.0",
@@ -16397,6 +16412,8 @@
 		},
 		"node_modules/zwitch": {
 			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",


### PR DESCRIPTION
# Audit report

This audit fix resolves 9 of the total 16 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [node-gettext](#user-content-node-gettext)
* [postcss](#user-content-postcss)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=4.2.0-beta.1
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: 1.1.0 - 3.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **high** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`