### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2423,9 +2423,9 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "8.24.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.24.0.tgz",
-			"integrity": "sha512-eMwV6verEW8j5XrHXDHz/gm+nnfUDKzXccCQFNvlu32fsxInyWVqe/6b2Fn1SkQmuZsa9YY0ejhzmFHjMZ1/1g==",
+			"version": "8.25.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.25.1.tgz",
+			"integrity": "sha512-tePbb9xiM94fkRGqbJXSVuSSseHOem8MS8ulRpmMIWB/g0BqROtigb7VHaVLKAsxgywPN/TqeMeyKFC8cQjptw==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",
@@ -14326,9 +14326,9 @@
 			}
 		},
 		"node_modules/swagger-ui": {
-			"version": "5.20.8",
-			"resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.20.8.tgz",
-			"integrity": "sha512-oew1ErjIsw9rr9w0opKIJ8e0uuUzrw/htX5GPg0g1xw/1xDd0ZxdpxF9+7hKJyGV3IEJhcQ+djnIhjanRoyNPA==",
+			"version": "5.21.0",
+			"resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.21.0.tgz",
+			"integrity": "sha512-zAY5P5nIWiYOuO0SWQk1x8/kL+pmarijO+oviWOp+SerfMpeokujYk6HknwEoeYNi4CtpO+kBj6Vm+8aswCBIA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/runtime-corejs3": "^7.26.10",


### PR DESCRIPTION
# Audit report

This audit fix resolves 11 of the total 18 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [postcss](#user-content-postcss)
* [prismjs](#user-content-prismjs)
* [react-syntax-highlighter](#user-content-react-syntax-highlighter)
* [refractor](#user-content-refractor)
* [swagger-ui](#user-content-swagger-ui)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=4.2.0-beta.1
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=6.2.0
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### prismjs <a href="#user-content-prismjs" id="prismjs">#</a>
* PrismJS DOM Clobbering vulnerability
* Severity: **moderate** (CVSS 4.9)
* Reference: [https://github.com/advisories/GHSA-x7hr-w5r2-h6wg](https://github.com/advisories/GHSA-x7hr-w5r2-h6wg)
* Affected versions: <1.30.0
* Package usage:
  * `node_modules/refractor/node_modules/prismjs`

### react-syntax-highlighter <a href="#user-content-react-syntax-highlighter" id="react-syntax-highlighter">#</a>
* Caused by vulnerable dependency:
  * [refractor](#user-content-refractor)
* Affected versions: >=6.0.0
* Package usage:
  * `node_modules/react-syntax-highlighter`

### refractor <a href="#user-content-refractor" id="refractor">#</a>
* Caused by vulnerable dependency:
  * [prismjs](#user-content-prismjs)
* Affected versions: <=4.6.0
* Package usage:
  * `node_modules/refractor`

### swagger-ui <a href="#user-content-swagger-ui" id="swagger-ui">#</a>
* Caused by vulnerable dependency:
  * [react-syntax-highlighter](#user-content-react-syntax-highlighter)
* Affected versions: >=3.30.0
* Package usage:
  * `node_modules/swagger-ui`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`